### PR TITLE
Fix and improve workflow environment configuration

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,8 +4,10 @@ on:
   workflow_call:
     inputs:
       node-version:
-        required: true
+        description: Node version to use for running audit-ci
+        required: false
         type: string
+        default: 14
 
 jobs:
   audit_ci:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: 8.0
+      php-extensions:
+        description: Comma-separated list of PHP extensions to install
+        required: false
+        type: string
     secrets:
       composer-auth:
         required: false
@@ -24,6 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.php-extensions }}
           tools: composer:v2, cs2pr
 
       - name: Get Composer cache directory

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: 8.0
+      php-extensions:
+        description: Comma-separated list of PHP extensions to install
+        required: false
+        type: string
     secrets:
       composer-auth:
         required: false
@@ -24,6 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.php-extensions }}
           tools: composer:v2
 
       - name: Get Composer cache directory

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,9 +4,10 @@ on:
   workflow_call:
     inputs:
       php-version:
-        description: PHP version to use for running the tests
-        required: true
+        description: PHP version to use for running PHPUnit
+        required: false
         type: string
+        default: 8.0
       php-extensions:
         description: Comma-separated list of PHP extensions to install
         required: false


### PR DESCRIPTION
- Allow PHP extensions to be set for the code style workflow (which is required when running Composer to install PHP_CodeSniffer)
- Allow PHP extensions to be set for the static analysis workflow (which is required when running Composer to install PHPStan)
- Set PHP 8.0 as the default for the PHPUnit workflow, for consistency with the other workflows
- Set Node 14 as the default for the Audit workflow, for consistency with the other workflows