### PR TITLE
Run audit-ci with --moderate instead of --medium

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,11 +23,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Setup audit-ci
-        run: npm install -g audit-ci
-
       - name: Audit NPM dependencies
-        run: audit-ci --medium
+        run: npx audit-ci --moderate
 
   sensiolabs_security_checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`--medium` does not exist and will let moderate, high, and critical vulnerabilities through.