### PR TITLE
Remove node-version input from audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
         run: npx audit-ci --moderate

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,13 +1,7 @@
 name: audit
 
 on:
-  workflow_call:
-    inputs:
-      node-version:
-        description: Node version to use for running audit-ci
-        required: false
-        type: string
-        default: 14
+  workflow_call: ~
 
 jobs:
   audit_ci:
@@ -20,8 +14,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v1
-        with:
-          node-version: ${{ inputs.node-version }}
 
       - name: Audit NPM dependencies
         run: npx audit-ci --moderate

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ on:
     branches: [ main, develop ]
 jobs:
   audit:
-    uses: 23g/actions/.github/workflows/audit.yml@v1
-    with:
-      node-version: 14
+    uses: 23g/actions/.github/workflows/audit.yml@v2
 ```
 
 ### Code style


### PR DESCRIPTION
This is a breaking change and therefore requires a new major (`v2`).

Also upgrades `actions/setup-node` to `v2`.