### PR TITLE
Add separate audit-npm workflow for projects without Composer

### DIFF
--- a/.github/workflows/audit-npm.yml
+++ b/.github/workflows/audit-npm.yml
@@ -3,10 +3,11 @@ name: audit-npm
 on:
   workflow_call:
     inputs:
-      arguments:
+      directory:
         type: string
+        description: The directory containing the package.json to audit
         required: false
-        default: --low
+        default: ./
 
 jobs:
   audit_ci:
@@ -21,4 +22,4 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci ${{ inputs.arguments }}
+        run: npx audit-ci --low --directory=${{ inputs.directory }}

--- a/.github/workflows/audit-npm.yml
+++ b/.github/workflows/audit-npm.yml
@@ -1,7 +1,12 @@
 name: audit-npm
 
 on:
-  workflow_call: ~
+  workflow_call:
+    inputs:
+      arguments:
+        type: string
+        required: false
+        default: --low
 
 jobs:
   audit_ci:
@@ -16,4 +21,4 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci --moderate
+        run: npx audit-ci ${{ inputs.arguments }}

--- a/.github/workflows/audit-npm.yml
+++ b/.github/workflows/audit-npm.yml
@@ -1,0 +1,19 @@
+name: audit-npm
+
+on:
+  workflow_call: ~
+
+jobs:
+  audit_ci:
+    runs-on: ubuntu-latest
+    name: Audit NPM dependencies
+    timeout-minutes: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+
+      - name: Audit NPM dependencies
+        run: npx audit-ci --moderate

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,7 +1,13 @@
 name: audit
 
 on:
-  workflow_call: ~
+  workflow_call:
+    inputs:
+      audit-ci-directory:
+        type: string
+        description: The directory containing the package.json to audit
+        required: false
+        default: ./
 
 jobs:
   audit_ci:
@@ -16,7 +22,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci --low
+        run: npx audit-ci --low --directory=${{ inputs.audit-ci-directory }}
 
   sensiolabs_security_checker:
     runs-on: ubuntu-latest

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci --moderate
+        run: npx audit-ci --low
 
   sensiolabs_security_checker:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ jobs:
     uses: 23g/actions/.github/workflows/audit.yml@v2
 ```
 
+> If your project does not use Composer, you may use the `audit-npm.yml@v2`
+> workflow instead.
+
 ### Code style
 
-Requires `23g/coding-standard` and a [PHP_CodeSniffer configuration file](https://github.com/23G/coding-standard/#configuration).
+Requires `23g/coding-standard` and
+a [PHP_CodeSniffer configuration file](https://github.com/23G/coding-standard/#configuration).
 
 ```yml
 # .github/workflows/code-style.yml


### PR DESCRIPTION
* New `audit-npm.yml` workflow for projects without Composer
* Use stricter audit (`--low` instead of `--moderate`)
* `audit-ci-directory` / `directory` input