### PR TITLE
Run audit-ci for high severity and above

### DIFF
--- a/.github/workflows/audit-npm.yml
+++ b/.github/workflows/audit-npm.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci --low --directory=${{ inputs.directory }}
+        run: npx audit-ci --high --directory=${{ inputs.directory }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: Audit NPM dependencies
-        run: npx audit-ci --low --directory=${{ inputs.audit-ci-directory }}
+        run: npx audit-ci --high --directory=${{ inputs.audit-ci-directory }}
 
   sensiolabs_security_checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Het is na 1 dag al gebleken dat dit niet helemaal lekker werkt. Nu wilt dit niet zeggen dat we niet alle vulnerabilities moeten fixen maar op deze manier hebben we meer controle wanneer we dit doen. Alleen high en critical moeten we direct fixen.