### PR TITLE
Run `composer install` with `--no-scripts` phpcs/phpstan

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts
         env:
           COMPOSER_AUTH: ${{ secrets.composer-auth }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts
         env:
           COMPOSER_AUTH: ${{ secrets.composer-auth }}
 


### PR DESCRIPTION
`--no-scripts` solves auto discovery issues (`php artisan package:discover`). It does NOT prevent PHPStan/PHPCS from working (which also have auto discovery based on scripts).